### PR TITLE
Extras

### DIFF
--- a/frontend/js/temp.js
+++ b/frontend/js/temp.js
@@ -198,10 +198,11 @@ const tzdateOptions = {
 };
 
 function makeTempChart(data) {
+    const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const opts = {
         title: "Temperature History",
         ...getSize(chartDiv),
-        tzDate: ts => uPlot.tzDate(new Date(ts * 1e3), 'Europe/Berlin'),
+        tzDate: ts => uPlot.tzDate(new Date(ts * 1e3), localTz),
         series: [
             {
                 value: "{YYYY}-{MM}-{DD} {HH}:{mm}:{ss}"
@@ -236,7 +237,7 @@ function makeTempChart(data) {
         ],
         axes: [
             {
-                values: (u, vals, space) => vals.map(v => uPlot.tzDate(new Date(v * 1e3), 'Europe/Berlin').toLocaleString("de-DE", tzdateOptions)),
+                values: (u, vals, space) => vals.map(v => uPlot.tzDate(new Date(v * 1e3), localTz).toLocaleString("de-DE", tzdateOptions)),
             },
             {
                 scale: 'C',
@@ -249,10 +250,11 @@ function makeTempChart(data) {
 }
 
 function makeHeaterChart(data) {
+    const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const opts = {
         title: "Heater Power History",
         ...getSize(heaterDiv),
-        tzDate: ts => uPlot.tzDate(new Date(ts * 1e3), 'Europe/Berlin'),
+        tzDate: ts => uPlot.tzDate(new Date(ts * 1e3), localTz),
         scales: {
             "%": {
                 auto: false,
@@ -279,7 +281,7 @@ function makeHeaterChart(data) {
         ],
         axes: [
             {
-                values: (u, vals, space) => vals.map(v => uPlot.tzDate(new Date(v * 1e3), 'Europe/Berlin').toLocaleString("de-DE", tzdateOptions)),
+                values: (u, vals, space) => vals.map(v => uPlot.tzDate(new Date(v * 1e3), localTz).toLocaleString("de-DE", tzdateOptions)),
             },
             {
                 side: 3,

--- a/src/hardware/tempsensors/TempSensorTSIC.cpp
+++ b/src/hardware/tempsensors/TempSensorTSIC.cpp
@@ -7,7 +7,8 @@
 #include "TempSensorTSIC.h"
 #include "Logger.h"
 
-#define MAX_CHANGERATE 15
+#define INITIAL_CHANGERATE 200
+#define MAX_CHANGERATE     15
 
 TempSensorTSIC::TempSensorTSIC(const int GPIOPin) {
     // Set pin to receive signal from the TSic 306
@@ -17,7 +18,22 @@ TempSensorTSIC::TempSensorTSIC(const int GPIOPin) {
 }
 
 bool TempSensorTSIC::sample_temperature(double& temperature) const {
-    const auto temp = tsicSensor_->getTemp(MAX_CHANGERATE);
+    static bool validTemps = false;
+    float temp = 0.0;
+
+    if (!validTemps) {
+        temp = tsicSensor_->getTemp(INITIAL_CHANGERATE);
+
+        if (temp >= 0.0 && temp <= 180.0) {
+            validTemps = true;
+        }
+        else {
+            LOGF(WARNING, "Temperature reading outside expected range: %0.01f", temp);
+        }
+    }
+    else {
+        temp = tsicSensor_->getTemp(MAX_CHANGERATE);
+    }
 
     if (temp == 222) {
         LOG(WARNING, "Temperature reading failed");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1280,9 +1280,7 @@ void loopPid() {
         websiteUpdateRunning = true;
 
         // send temperatures to website endpoint
-        if (WiFi.status() == WL_CONNECTED && !offlineMode) {
-            sendTempEvent(temperature, brewSetpoint, pidOutput / 10); // pidOutput is promill, so /10 to get percent value
-        }
+        sendTempEvent(temperature, brewSetpoint, pidOutput / 10); // pidOutput is promill, so /10 to get percent value
 
         lastTempEvent = millis();
 

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -314,6 +314,7 @@ inline int writeSysParamsToMQTT(const bool continueOnError = true) {
                 }
 
                 LOGF(WARNING, "Parameter %s not found for MQTT topic %s, skipping", parameterId, mqttTopic);
+                ++mqttVarsIt;
                 continue;
             }
 
@@ -342,6 +343,7 @@ inline int writeSysParamsToMQTT(const bool continueOnError = true) {
                     }
 
                     LOGF(WARNING, "Skipping unknown parameter type for topic %s", mqttTopic);
+                    ++mqttVarsIt;
                     continue;
             }
 


### PR DESCRIPTION
Reduced ram usage for graph history by storing as x100 in an int, which uses half the space and still provides 2 decimal place precision.
History array is now populated every second even if wifi is disconnected or an AP is in use.
Changed graph to browser local time, the "de-DE" that is still present just defines 24hour time.
Added TSIC initialise to catch poor first readings, I don't have a sensor to test but the scenario was a first reading of near -50C, which I think forces all later readings to be rejected.