### PR TITLE
testing pins for SPI and encoder

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -44,6 +44,7 @@ lib_deps =
     git+https://github.com/tzapu/WiFiManager @ 2.0.17
     h2zero/NimBLE-Arduino@^2.3.6
     git+https://github.com/rancilio-pid/AcaiaArduinoBLE#v4.0.1
+	madhephaestus/ESP32Encoder @ ^0.11.7
 
 extra_scripts =
     pre:auto_firmware_version.py

--- a/src/Config.h
+++ b/src/Config.h
@@ -341,6 +341,7 @@ class Config {
             _configDefs.emplace("hardware.switches.hot_water.enabled", ConfigDef::forBool(false));
             _configDefs.emplace("hardware.switches.hot_water.type", ConfigDef::forInt(Switch::TOGGLE, 0, 2));
             _configDefs.emplace("hardware.switches.hot_water.mode", ConfigDef::forInt(Switch::NORMALLY_OPEN, 0, 1));
+            _configDefs.emplace("hardware.switches.encoder.enabled", ConfigDef::forBool(false));
 
             // Hardware - LEDs
             _configDefs.emplace("hardware.leds.status.enabled", ConfigDef::forBool(false));

--- a/src/ParameterRegistry.cpp
+++ b/src/ParameterRegistry.cpp
@@ -1065,6 +1065,15 @@ void ParameterRegistry::initialize(Config& config) {
         [] { return true; },
         true
     );
+    
+    addBoolConfigParam(
+        "hardware.switches.encoder.enabled",
+        "Enable Encoder",
+        sHardwareSwitchSection,
+        2241,
+        nullptr,
+        "Enable encoder with button"
+    );
 
     // LEDs
     addBoolConfigParam(

--- a/src/display/displayTemplateScale.h
+++ b/src/display/displayTemplateScale.h
@@ -60,6 +60,7 @@ inline void printScreen() {
     u8g2->print(setpoint, 1);
     u8g2->print(static_cast<char>(176));
     u8g2->print("C");
+    u8g2->print(menuLevel == 1 ? "<" : " ");
 
     if (scale) {
         // Show current weight if scale has no error

--- a/src/hardware/pinmapping.h
+++ b/src/hardware/pinmapping.h
@@ -16,6 +16,66 @@
 #define TARGET_BOARD_ESP32_CLASSIC
 #endif
 
+
+/* available pins
+https://randomnerdtutorials.com/esp32-s3-devkitc-pinout-guide/
+https://github.com/atomic14/esp32-s3-pinouts?tab=readme-ov-file
+
+20 Analog-to-Digital Converter (ADC) channels
+4 SPI interfaces
+3 UART interfaces
+2 I2C interfaces
+8 PWM output channel
+2 I2S interfaces
+14 Capacitive sensing GPIOs
+
+
+AVOID!
+GPIO 26 (Flash/PSRAM SPICS1)
+GPIO 27 (Flash/PSRAM SPIHD)
+GPIO 28 (Flash/PSRAM SPIWP)
+GPIO 29 (Flash/PSRAM SPICS0)
+GPIO 30 (Flash/PSRAM SPICLK)
+GPIO 31 (Flash/PSRAM SPIQ)
+GPIO 32 (Flash/PSRAM SPID)
+strapping pins
+GPIO 0
+GPIO 3
+GPIO 45
+GPIO 46
+octal ram
+GPIO 35
+GPIO 36
+GPIO 37
+
+
+
+RTCGPIOs
+RTC_GPIO0  (GPIO0)
+to
+RTC_GPIO21 (GPIO21)
+
+SPI	MOSI	MISO	CLK	CS
+HSPI (SPI 2)	GPIO 11	GPIO 13	GPIO 12	GPIO 10
+VSPI (SPI 3)	GPIO 35	GPIO 37	GPIO 36	GPIO 39
+
+
+
+GPIOs on board (36)
+0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21
+35,36,37,38,39,40,41,42,43,44,45,46,47,48
+
+minus avoid (32)
+1,2,
+4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21
+38,39,40,41,42,43,44,
+47,48
+
+left to use
+3 (strapping) ,18
+*/
+
+
 #ifdef TARGET_BOARD_ESP32_S3
 // ESP32-S3 Pin Mapping (16MB Flash, 8MB PSRAM)
 #define PIN_POWERSWITCH 15
@@ -23,19 +83,23 @@
 #define PIN_STEAMSWITCH 17
 #define PIN_WATERSWITCH 18
 
-#define PIN_ROTARY_DT  4
-#define PIN_ROTARY_CLK 5
-#define PIN_ROTARY_SW  6
+#define PIN_ROTARY_DT  4 // tested 
+#define PIN_ROTARY_CLK 5 // tested 
+#define PIN_ROTARY_SW  6 // tested 
 
-#define PIN_TEMPSENSOR      7
-#define PIN_WATERTANKSENSOR 41
-#define PIN_HXDAT           42
-#define PIN_HXDAT2          8
-#define PIN_HXCLK           9
+#define PIN_TEMPSENSOR      7 // tested as CS pin kType
+#define PIN_TEMPSENSOR2     10
+#define PIN_WATERTANKSENSOR 20
+#define PIN_HXDAT           19
+#define PIN_HXDAT2          44
+#define PIN_HXCLK           47
+#define PIN_HXCLK2          48  // could be done in software by writing a custom read function
 
 #define PIN_VALVE  12
 #define PIN_PUMP   13
+#define PIN_PUMP2  41
 #define PIN_HEATER 14
+#define PIN_HEATER2 42
 
 #define PIN_STATUSLED 38
 #define PIN_BREWLED   39
@@ -43,8 +107,14 @@
 
 #define PIN_ZC 21
 
-#define PIN_I2CSCL 10
-#define PIN_I2CSDA 11
+#define PIN_I2CSCL 9 // tested, HWI2C
+#define PIN_I2CSDA 8 // tested, HWI2C
+#define PIN_SPIMOSI 11 // tested, HWSPI
+#define PIN_SPIMISO 13 // tested, HWSPI
+#define PIN_SPICLK 12 // tested, HWSPI
+#define PIN_OLEDCS 0 // tested, strapping
+#define OLED_RESET 18 // not used, currently on Enable Pin and testing stability
+#define PIN_SPIDC 46 // tested, strapping
 
 #else
 // ESP32 Classic Pin Mapping

--- a/src/hardware/pinmapping.h
+++ b/src/hardware/pinmapping.h
@@ -16,7 +16,6 @@
 #define TARGET_BOARD_ESP32_CLASSIC
 #endif
 
-
 /* available pins
 https://randomnerdtutorials.com/esp32-s3-devkitc-pinout-guide/
 https://github.com/atomic14/esp32-s3-pinouts?tab=readme-ov-file
@@ -72,9 +71,7 @@ minus avoid (32)
 47,48
 
 left to use
-3 (strapping) ,18
 */
-
 
 #ifdef TARGET_BOARD_ESP32_S3
 // ESP32-S3 Pin Mapping (16MB Flash, 8MB PSRAM)
@@ -83,9 +80,9 @@ left to use
 #define PIN_STEAMSWITCH 17
 #define PIN_WATERSWITCH 18
 
-#define PIN_ROTARY_DT  4 // tested 
-#define PIN_ROTARY_CLK 5 // tested 
-#define PIN_ROTARY_SW  6 // tested 
+#define PIN_ROTARY_DT  4      // tested S2
+#define PIN_ROTARY_CLK 5      // tested S1
+#define PIN_ROTARY_SW  6      // tested SW
 
 #define PIN_TEMPSENSOR      7 // tested as CS pin kType
 #define PIN_TEMPSENSOR2     10
@@ -93,12 +90,12 @@ left to use
 #define PIN_HXDAT           19
 #define PIN_HXDAT2          44
 #define PIN_HXCLK           47
-#define PIN_HXCLK2          48  // could be done in software by writing a custom read function
+#define PIN_HXCLK2          48 // could be done in software by writing a custom read function
 
-#define PIN_VALVE  12
-#define PIN_PUMP   13
-#define PIN_PUMP2  41
-#define PIN_HEATER 14
+#define PIN_VALVE   12
+#define PIN_PUMP    13
+#define PIN_PUMP2   41
+#define PIN_HEATER  14
 #define PIN_HEATER2 42
 
 #define PIN_STATUSLED 38
@@ -107,14 +104,15 @@ left to use
 
 #define PIN_ZC 21
 
-#define PIN_I2CSCL 9 // tested, HWI2C
-#define PIN_I2CSDA 8 // tested, HWI2C
-#define PIN_SPIMOSI 11 // tested, HWSPI
-#define PIN_SPIMISO 13 // tested, HWSPI
-#define PIN_SPICLK 12 // tested, HWSPI
-#define PIN_OLEDCS 0 // tested, strapping
-#define OLED_RESET 18 // not used, currently on Enable Pin and testing stability
-#define PIN_SPIDC 46 // tested, strapping
+#define PIN_I2CSCL        9  // tested, HWI2C
+#define PIN_I2CSDA        8  // tested, HWI2C
+#define PIN_SPIMOSI       11 // tested, HWSPI - can be other pins if SPI.begin( called before u8g2, tested 42
+#define PIN_SPIMISO       13 // tested, HWSPI - can be other pins if SPI.begin( called before u8g2, tested 41
+#define PIN_SPICLK        12 // tested, HWSPI - can be other pins if SPI.begin( called before u8g2, tested 48
+#define PIN_SPIDC         46 // tested, strapping
+#define PIN_OLEDCS        0  // tested, strapping
+#define PIN_OLEDBACKLIGHT 3  // not tested
+#define PIN_OLEDRESET     18 // not used, currently on Enable Pin and testing stability
 
 #else
 // ESP32 Classic Pin Mapping

--- a/src/hardware/rotaryEncoder.h
+++ b/src/hardware/rotaryEncoder.h
@@ -1,0 +1,89 @@
+#pragma once
+
+ESP32Encoder encoder;
+
+unsigned long startMillisEncoderSwitch = 0;
+unsigned long EncoderSwitchBackflushInterval = 2000;
+unsigned long EncoderSwitchControlInterval = 800;
+bool encoderSwitchPressed = false;
+bool displayProfileDescription = false;
+bool blockScroll = false;
+int descriptionScrollY = 0;
+
+void initEncoder() {
+    ESP32Encoder::useInternalWeakPullResistors = puType::up;
+    // encoder.attachHalfQuad(PIN_ROTARY_DT, PIN_ROTARY_CLK);
+    encoder.attachFullQuad(PIN_ROTARY_DT, PIN_ROTARY_CLK);
+    encoder.setCount(0);
+}
+
+int getEncoderDelta(void) {
+    static long lastValueDelta = 0;
+    static long lastValueSent = 0;
+    long value = encoder.getCount();
+    int delta = (value - lastValueDelta) / (menuLevel == 4 ? 1 : 2); // smooth scroll for specific menuLevels
+
+    if (lastValueSent != value) {
+        LOGF(INFO, "Rotary Encoder Value: %i", value);
+        lastValueSent = value;
+    }
+
+    if (delta != 0) {
+        lastValueDelta = value;
+    }
+
+    return delta;
+}
+
+void encoderHandler() {
+    if (!config.get<bool>("hardware.switches.encoder.enabled") || encoderSwitch == nullptr) {
+        return;
+    }
+
+    int delta = getEncoderDelta();
+
+    if (machineState != kBackflush) {
+        if (delta != 0) {
+            if (menuLevel == 1) {
+                brewSetpoint = constrain(brewSetpoint + ((float)delta * 0.1), BREW_SETPOINT_MIN, BREW_SETPOINT_MAX);
+                config.set<double>("brew.setpoint", brewSetpoint);
+            }
+        }
+    }
+
+    if (encoderSwitch->isPressed()) {
+        if (encoderSwitchPressed == false) {
+            startMillisEncoderSwitch = millis();
+            encoderSwitchPressed = true;
+        }
+    }
+    else {
+        if (encoderSwitchPressed == true) {
+            unsigned long duration = millis() - startMillisEncoderSwitch;
+            if (duration > EncoderSwitchBackflushInterval) { // toggle every interval
+                if (machineState == kBackflush) {
+                    backflushOn = false;
+                    startMillisEncoderSwitch = millis();
+                }
+
+                if (machineState == kPidNormal) {
+                    backflushOn = true;
+                    startMillisEncoderSwitch = millis();
+                }
+            }
+            else if (duration > EncoderSwitchControlInterval) { // toggle every interval
+                menuLevel = 0;
+                if (!config.save()) {
+                    LOG(ERROR, "Failed to save config to filesystem!");
+                }
+            }
+            else {
+                menuLevel = (menuLevel == 1) ? 0 : 1; // this is where it toggles between different levels
+            }
+
+            LOGF(INFO, "Rotary Encoder Button down for: %lu ms, menuLevel: %d", duration, menuLevel);
+        }
+
+        encoderSwitchPressed = false;
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 // Libraries & Dependencies
 #include "Logger.h"
 #include <ArduinoOTA.h>
+#include <ESP32Encoder.h>
 #include <LittleFS.h>
 #include <PID_v1.h>  // for PID calculation
 #include <U8g2lib.h> // i2c display
@@ -97,6 +98,9 @@ bool featureFullscreenHotWaterTimer = false;
 double postBrewTimerDuration = POST_BREW_TIMER_DURATION;
 bool featureHeatingLogo = false;
 
+// encoder menu
+int menuLevel = 0;
+
 // WiFi
 WiFiManager wm;
 constexpr unsigned long wifiConnectionDelay = WIFICONNECTIONDELAY;
@@ -130,6 +134,7 @@ unsigned long lastDisplayUpdate = 0;
 #include "utils/timingDebug.h"
 
 Switch* waterTankSensor = nullptr;
+Switch* encoderSwitch = nullptr;
 
 GPIOPin* statusLedPin = nullptr;
 GPIOPin* brewLedPin = nullptr;
@@ -217,6 +222,7 @@ bool steamFirstON = false;
 PID bPID(&temperature, &pidOutput, &setpoint, aggKp, aggKi, aggKd, 1, DIRECT);
 
 #include "brewHandler.h"
+#include "hardware/rotaryEncoder.h"
 #include "hotWaterHandler.h"
 
 // Other variables
@@ -1042,6 +1048,11 @@ void setup() {
         waterTankSensor = new IOSwitch(PIN_WATERTANKSENSOR, (mode == Switch::NORMALLY_OPEN ? GPIOPin::IN_PULLDOWN : GPIOPin::IN_PULLUP), Switch::TOGGLE, mode, !mode);
     }
 
+    if (config.get<bool>("hardware.switches.encoder.enabled")) {
+        encoderSwitch = new IOSwitch(PIN_ROTARY_SW, GPIOPin::IN_PULLUP, Switch::TOGGLE, Switch::NORMALLY_CLOSED, Switch::NORMALLY_CLOSED);
+        initEncoder();
+    }
+
     if (!config.get<bool>("system.offline_mode")) { // WiFi Mode
         wiFiSetup();
         serverSetup();
@@ -1391,6 +1402,7 @@ void loopPid() {
     hotWaterHandler();
     valveSafetyShutdownCheck();
     testTimer();
+    encoderHandler();
 
     if (config.get<bool>("hardware.switches.brew.enabled")) {
         shouldDisplayBrewTimer();


### PR DESCRIPTION
Added potential extra pins for the new hardware, depends on priorities whether they get used or not.

SPI tested working with an 0.96" SSD1306 display, with a k type thermocouple sharing the same bus.

Includes comments on pins for reference.